### PR TITLE
Add docking variant

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,16 +8,28 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_:
-        CONFIG: linux_64_
+      linux_64_imgui_variantdefault:
+        CONFIG: linux_64_imgui_variantdefault
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_aarch64_:
-        CONFIG: linux_aarch64_
+      linux_64_imgui_variantdocking:
+        CONFIG: linux_64_imgui_variantdocking
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_ppc64le_:
-        CONFIG: linux_ppc64le_
+      linux_aarch64_imgui_variantdefault:
+        CONFIG: linux_aarch64_imgui_variantdefault
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_imgui_variantdocking:
+        CONFIG: linux_aarch64_imgui_variantdocking
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_ppc64le_imgui_variantdefault:
+        CONFIG: linux_ppc64le_imgui_variantdefault
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_ppc64le_imgui_variantdocking:
+        CONFIG: linux_ppc64le_imgui_variantdocking
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,11 +8,17 @@ jobs:
     vmImage: macOS-13
   strategy:
     matrix:
-      osx_64_:
-        CONFIG: osx_64_
+      osx_64_imgui_variantdefault:
+        CONFIG: osx_64_imgui_variantdefault
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_:
-        CONFIG: osx_arm64_
+      osx_64_imgui_variantdocking:
+        CONFIG: osx_64_imgui_variantdocking
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_imgui_variantdefault:
+        CONFIG: osx_arm64_imgui_variantdefault
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_imgui_variantdocking:
+        CONFIG: osx_arm64_imgui_variantdocking
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables: {}

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -8,8 +8,11 @@ jobs:
     vmImage: windows-2022
   strategy:
     matrix:
-      win_64_:
-        CONFIG: win_64_
+      win_64_imgui_variantdefault:
+        CONFIG: win_64_imgui_variantdefault
+        UPLOAD_PACKAGES: 'True'
+      win_64_imgui_variantdocking:
+        CONFIG: win_64_imgui_variantdocking
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables:

--- a/.ci_support/linux_64_imgui_variantdefault.yaml
+++ b/.ci_support/linux_64_imgui_variantdefault.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+imgui_variant:
+- default
 sdl2:
 - '2'
 target_platform:

--- a/.ci_support/linux_64_imgui_variantdocking.yaml
+++ b/.ci_support/linux_64_imgui_variantdocking.yaml
@@ -1,0 +1,29 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+imgui_variant:
+- docking
+sdl2:
+- '2'
+target_platform:
+- linux-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_imgui_variantdefault.yaml
+++ b/.ci_support/linux_aarch64_imgui_variantdefault.yaml
@@ -1,0 +1,29 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+imgui_variant:
+- default
+sdl2:
+- '2'
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_aarch64_imgui_variantdocking.yaml
+++ b/.ci_support/linux_aarch64_imgui_variantdocking.yaml
@@ -1,0 +1,29 @@
+c_compiler:
+- gcc
+c_compiler_version:
+- '13'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+imgui_variant:
+- docking
+sdl2:
+- '2'
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/linux_ppc64le_imgui_variantdefault.yaml
+++ b/.ci_support/linux_ppc64le_imgui_variantdefault.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+imgui_variant:
+- default
 sdl2:
 - '2'
 target_platform:

--- a/.ci_support/linux_ppc64le_imgui_variantdocking.yaml
+++ b/.ci_support/linux_ppc64le_imgui_variantdocking.yaml
@@ -1,29 +1,29 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '18'
+- '13'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '11.0'
+- '2.17'
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '18'
-macos_machine:
-- arm64-apple-darwin20.0.0
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
+imgui_variant:
+- docking
 sdl2:
 - '2'
 target_platform:
-- osx-arm64
+- linux-ppc64le
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_64_imgui_variantdefault.yaml
+++ b/.ci_support/osx_64_imgui_variantdefault.yaml
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+imgui_variant:
+- default
 macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:

--- a/.ci_support/osx_64_imgui_variantdocking.yaml
+++ b/.ci_support/osx_64_imgui_variantdocking.yaml
@@ -1,27 +1,33 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.15'
+MACOSX_SDK_VERSION:
+- '10.15'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '13'
+- '18'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
-cdt_name:
-- conda
+- '10.15'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '13'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- '18'
+imgui_variant:
+- docking
+macos_machine:
+- x86_64-apple-darwin13.4.0
+macos_min_version:
+- '10.15'
 sdl2:
 - '2'
 target_platform:
-- linux-aarch64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_arm64_imgui_variantdefault.yaml
+++ b/.ci_support/osx_arm64_imgui_variantdefault.yaml
@@ -1,0 +1,31 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '18'
+imgui_variant:
+- default
+macos_machine:
+- arm64-apple-darwin20.0.0
+sdl2:
+- '2'
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_imgui_variantdocking.yaml
+++ b/.ci_support/osx_arm64_imgui_variantdocking.yaml
@@ -1,0 +1,31 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '18'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '18'
+imgui_variant:
+- docking
+macos_machine:
+- arm64-apple-darwin20.0.0
+sdl2:
+- '2'
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/win_64_imgui_variantdefault.yaml
+++ b/.ci_support/win_64_imgui_variantdefault.yaml
@@ -1,0 +1,16 @@
+c_compiler:
+- vs2019
+c_stdlib:
+- vs
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- vs2019
+imgui_variant:
+- default
+sdl2:
+- '2'
+target_platform:
+- win-64

--- a/.ci_support/win_64_imgui_variantdocking.yaml
+++ b/.ci_support/win_64_imgui_variantdocking.yaml
@@ -8,6 +8,8 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2019
+imgui_variant:
+- docking
 sdl2:
 - '2'
 target_platform:

--- a/README.md
+++ b/README.md
@@ -27,45 +27,87 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64</td>
+              <td>linux_64_imgui_variantdefault</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=21758&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imgui-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imgui-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_imgui_variantdefault" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64</td>
+              <td>linux_64_imgui_variantdocking</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=21758&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imgui-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imgui-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_imgui_variantdocking" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le</td>
+              <td>linux_aarch64_imgui_variantdefault</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=21758&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imgui-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imgui-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_imgui_variantdefault" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64</td>
+              <td>linux_aarch64_imgui_variantdocking</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=21758&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imgui-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imgui-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_imgui_variantdocking" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64</td>
+              <td>linux_ppc64le_imgui_variantdefault</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=21758&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imgui-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imgui-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_imgui_variantdefault" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64</td>
+              <td>linux_ppc64le_imgui_variantdocking</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=21758&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imgui-feedstock?branchName=main&jobName=win&configuration=win%20win_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imgui-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_ppc64le_imgui_variantdocking" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_imgui_variantdefault</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=21758&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imgui-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_imgui_variantdefault" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_imgui_variantdocking</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=21758&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imgui-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_imgui_variantdocking" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_imgui_variantdefault</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=21758&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imgui-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_imgui_variantdefault" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_imgui_variantdocking</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=21758&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imgui-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_imgui_variantdocking" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_imgui_variantdefault</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=21758&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imgui-feedstock?branchName=main&jobName=win&configuration=win%20win_64_imgui_variantdefault" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_imgui_variantdocking</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=21758&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imgui-feedstock?branchName=main&jobName=win&configuration=win%20win_64_imgui_variantdocking" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,3 +2,6 @@ macos_min_version:             # [osx and x86_64]
   - 10.15                      # [osx and x86_64]
 c_stdlib_version:              # [osx and x86_64]
   - 10.15                      # [osx and x86_64]
+imgui_variant:
+  - default
+  - docking

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,19 +1,27 @@
 context:
   name: imgui
   version: "1.91.8"
+  build_number: 0
+  docking: ${{ "true" if imgui_variant == "docking" else "false" }}
 
 package:
   name: ${{ name|lower }}
   version: ${{ version }}
 
 source:
-  - url: https://github.com/ocornut/${{ name }}/archive/v${{ version }}.tar.gz
-    sha256: db3a2e02bfd6c269adf0968950573053d002f40bdfb9ef2e4a90bce804b0f286
+  - if: docking == "true"
+    then:
+    - url: https://github.com/ocornut/${{ name }}/archive/v${{ version }}-docking.tar.gz
+      sha256: 55f5e65abea635f2a8bfa9a92cd966448a363a262cf6dead7cc662fb0ab37612
+    else:
+    - url: https://github.com/ocornut/${{ name }}/archive/v${{ version }}.tar.gz
+      sha256: db3a2e02bfd6c269adf0968950573053d002f40bdfb9ef2e4a90bce804b0f286
   - path: CMakeLists.txt
   - path: imgui-config.cmake.in
 
 build:
-  number: 0
+  number: ${{ build_number }}
+  string: ${{ "docking_" if imgui_variant == "docking" }}h${{ hash }}_${{ build_number }}
 
 requirements:
   build:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -21,6 +21,9 @@ source:
 
 build:
   number: ${{ build_number }}
+  variant:
+    # down-prioritize the docking variant versus default
+    down_prioritize_variant: ${{ 1 if imgui_variant == "docking" else 0 }}      
   string: ${{ "docking_" if imgui_variant == "docking" }}h${{ hash }}_${{ build_number }}
 
 requirements:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,7 +1,7 @@
 context:
   name: imgui
   version: "1.91.8"
-  build_number: 0
+  build_number: 1
   docking: ${{ "true" if imgui_variant == "docking" else "false" }}
 
 package:


### PR DESCRIPTION
ImGui repository manages two parallel official branches for years now: the master default branch and the "docking" branch which offers some advanced features such as [Docking](https://github.com/ocornut/imgui/wiki/Docking) and [Multi Viewport](https://github.com/ocornut/imgui/wiki/Multi-Viewports).
Unfortunately, it seems that is parallel cycle release is not planned to be handled differently, but the good news is that both variants (master and docking) are released at the same time.

Some software rely on this "docking" version of ImGui so a conda packaging would be relevant.

This PR propose to add a variant for the "docking" release. The mechanism looks well suited as only source tarball differs, and build scripts and dependencies are the same.

At this point, the default ImGui package would keep its build suffix (without variant) and "docking" variant would integrate a dedicated suffix. But this could be handled differently, I wanted to have your opinion on that.

Also, the "docking" variant would be down prioritized w.r.t. default (master) package.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number 
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
